### PR TITLE
Add bulk downloader

### DIFF
--- a/bulk_download.js
+++ b/bulk_download.js
@@ -1,0 +1,11 @@
+files = document.getElementsByClassName('hhr-table-new__row-cell cell--fileName')
+
+
+for (var i = 0; i < files.length; i++) {
+    try {
+        window.open(files[i].innerChild);
+    } catch (error) {
+        console.info(error)
+    }
+
+}


### PR DESCRIPTION
Two lines to copy big chunk of files from a page. Testing only on Firefox.